### PR TITLE
Fixes quantize opts to be optional

### DIFF
--- a/src/pnnquant2.js
+++ b/src/pnnquant2.js
@@ -139,14 +139,14 @@ function create_bin_list(data, format) {
   return bins;
 }
 
-export default function quantize(rgba, maxColors, opts) {
+export default function quantize(rgba, maxColors, opts = {}) {
   const {
     format = "rgb565",
     clearAlpha = true,
     clearAlphaColor = 0x00,
     clearAlphaThreshold = 0,
     oneBitAlpha = false,
-  } = opts || {};
+  } = opts;
 
   if (!rgba || !rgba.buffer) {
     throw new Error('quantize() expected RGBA Uint8Array data');


### PR DESCRIPTION
on line 160, there is a direct usage of `opts.` which breaks as "useSqrt not in undefined" error if opts was not provided.